### PR TITLE
Relax restriction on when Link should be parsed

### DIFF
--- a/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
+++ b/Libraries/dotNetRDF/JsonLd/DefaultDocumentLoader.cs
@@ -77,7 +77,7 @@ namespace VDS.RDF.JsonLd
             }
 
             // If content type is application/ld+json the context link header is ignored
-            if (!contentType.Any(x => x.Contains("application/ld+json")))
+            if (!contentType.Any(x => x.Contains("application/ld+json")) && !contentType.Any(x => x.Contains("application/json")))
             {
                 var contextLinks = ParseLinkHeaders(client.ResponseHeaders.GetValues("Link"))
                     .Where(x => x.RelationTypes.Contains(JsonLdVocabulary.Context))


### PR DESCRIPTION
Fixes document loading when context is hosted in GitHub which returns `application/json` as content type.